### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Fly Deploy


### PR DESCRIPTION
Potential fix for [https://github.com/codycordova/codytoken/security/code-scanning/1](https://github.com/codycordova/codytoken/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves deploying code and does not modify repository contents or interact with pull requests, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
