### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/codycordova/codytoken/security/code-scanning/8](https://github.com/codycordova/codytoken/security/code-scanning/8)

To fix the problem, you should add an explicit `permissions` block to the workflow file. The best way to do this is to add the block at the top level of the workflow (before `jobs:`), which will apply the permissions to all jobs unless overridden at the job level. The minimal starting point is to set all permissions to `none`, and then selectively grant only the permissions required for the workflow to function. For most CI/CD pipelines that only check out code, build, test, and deploy (without interacting with issues, pull requests, or repository contents), `contents: read` is usually sufficient. If any job requires additional permissions (e.g., to create a deployment, comment on a PR, etc.), you can add those as needed. In this case, since the jobs do not appear to require write access, adding:

```yaml
permissions:
  contents: read
```

at the top level (after the `name:` and before `on:`) is the best fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
